### PR TITLE
Additional check to see if the scene is already loaded. 

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1496,7 +1496,18 @@ namespace Unity.Netcode
                 // don't try to reload it.
                 shouldPassThrough = true;
             }
-
+            else
+            {
+                // Another check to see if the client already has loaded the scene to be loaded
+                Scene existingScene = SceneManager.GetSceneByName(sceneName);
+                if (existingScene.isLoaded)
+                {
+                    // If the scene is already loaded, then pass through and
+                    // don't try to reload it.
+                    shouldPassThrough = true;
+                }
+            }
+			
 #if UNITY_INCLUDE_TESTS
             if (m_IsRunningUnitTest)
             {


### PR DESCRIPTION
## Summary
Without this we end up with duplicate scenes in a multi-scene environment.

I stumbled upon this issue when I was working with multiple scenes. If I manually loaded the required scenes beforehand, the NetworkSceneManager only dismissed reloading the currently active scene. Other scenes were loaded a second time and caused trouble. Disabling SceneManagment didn't help either, because all in-scene NetworkObjects caused problems.

### PR Checklist
- [ ] Have you added a backport label (if needed)? For example, the `type:backport-release-*` label. After you backport the PR, the label changes to `stat:backported-release-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR or a link to the documenation repo PR if this is a manual update. 

## Testing and Documentation
* No tests have been added.
